### PR TITLE
Improvement of the wording in many places

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# Lan Server Properties
-For Minecraft 1.16 and above, Forge version >= 28
+# LAN Server Properties
+For Minecraft 1.12–1.16, and Forge.
 
-When this mod is installed, it will add a few new things to the "Open to LAN" Gui, which then allows the user to start the LAN game on a specific port, and also provides an option to disable the "online mode". Disabling the "online mode" allows unauthenticated players to join the game.
+When this mod is installed, it enhances the vanilla Minecraft "Open to LAN" screen, which now also:
+* Allows for a port customization
+* Allows a user to disable the online mode, so that also unauthenticated players can join the LAN server.
 
 ## For developers
-To modify and debug the code, first import the repo as a gradle project in Eclipse IDE, then run the ForgeGradle task `genEclipseRuns`.
+To modify and debug the code, first import the repo as a Gradle project in Eclipse IDE, and then run the ForgeGradle task `genEclipseRuns`.

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -13,9 +13,9 @@ credits="the Chinese Institution of Scientific Minecraft Mod (CISM)"
 authors="Rikka0w0"
 
 description='''
-Enhance the vanilla "Open to LAN" Gui which:
-1. Allows listening port customization
-2. Allows the user to disable the online mode, so that unauthenticated players can join the game.
+Enhances the vanilla Minecraft "Open to LAN" screen, which now also:
+1. Allows for a port customization
+2. Allows a user to disable the online mode, so that also unauthenticated players can join the LAN server.
 '''
 
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.

--- a/src/main/resources/assets/lanserverproperties/lang/en_us.json
+++ b/src/main/resources/assets/lanserverproperties/lang/en_us.json
@@ -1,5 +1,5 @@
 {
-	"lanserverproperties.gui.online_mode": "Online Mode",
-	"lanserverproperties.gui.online_mode_desc": "Disable this will allow unauthenticated connections",
-	"lanserverproperties.gui.port": "Listening Port"
+  "lanserverproperties.gui.online_mode": "Online Mode",
+  "lanserverproperties.gui.online_mode_desc": "Disabling online mode will allow also unauthenticated players to join the LAN server.",
+  "lanserverproperties.gui.port": "Port"
 }

--- a/src/main/resources/assets/lanserverproperties/lang/zh_cn.json
+++ b/src/main/resources/assets/lanserverproperties/lang/zh_cn.json
@@ -1,5 +1,5 @@
 {
-	"lanserverproperties.gui.online_mode": "在线模式",
-	"lanserverproperties.gui.online_mode_desc": "禁用此选项将允许非正版玩家加入",
-	"lanserverproperties.gui.port": "监听端口"
+  "lanserverproperties.gui.online_mode": "在线模式",
+  "lanserverproperties.gui.online_mode_desc": "禁用此选项将允许非正版玩家加入",
+  "lanserverproperties.gui.port": "监听端口"
 }


### PR DESCRIPTION
I did the following:
* improved the `lanserverproperties.gui.online_mode_desc` description to make it more understandable and accurate
* changed "Listening Port" to just "Port" in the `lanserverproperties.gui.port` string 
* changed indentations in the JSON files to make them use 2 whitespace characters instead of tabs, as the vast majority of Minecraft mods use them
* improved wording of the mod description in the mods.toml file to make it more accurate
* unified the description between the mods.toml file and the GitHub README.md file
* made several other, lesser changes in the README.md file.

If you don't like some of my changes, please let me know. In such case I'll update them based on your feedback.