### PR TITLE
Updated fabric.mod.json to include version number

### DIFF
--- a/src/fabric/resources/fabric.mod.json
+++ b/src/fabric/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "lanserverproperties",
-  "version": "${version}",
+  "version": "1.4.0",
 
   "name": "Lan Server Properties",
   "description": "Enhances the vanilla Minecraft \"Open to LAN\" screen, which now also:\n1. Allows for a port customization\n2. Allows a user to disable the online mode, so that also unauthenticated players can join the LAN server.",


### PR DESCRIPTION
The version tag in fabric.mod.json did not include a proper version number but instead the placeholder $(version). This led to an inability to identify the version in mod lists, such as Mod Menu and the MultiMC mods list.

![image](https://user-images.githubusercontent.com/43829531/96671697-6d6ab600-1330-11eb-8360-ef45300488cd.png)